### PR TITLE
feat: configurable config strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Via Composer
 $ composer require anfischer/cloner
 ```
 
+The package will automatically register its service provider.
+
 ## Usage
 
 ``` php
@@ -67,6 +69,38 @@ $cloner = new Cloner(new CloneService, new PersistenceService);
 $persistedModel = $cloner->cloneAndPersist($someEloquentModel);
 
 ```
+
+## Configuration
+
+To publish the config file to config/cloner.php run:
+
+```
+php artisan vendor:publish --provider="Anfischer\Cloner\ClonerServiceProvider"
+```
+
+Cloner supports various persistence strategies by default. These can be configured
+by modifying the configuration in `config/cloner.php`.
+
+For example
+
+```
+return [
+
+    'persistence_strategies' => [
+        Illuminate\Database\Eloquent\Relations\HasOne::class =>
+            Anfischer\Cloner\Strategies\PersistHasOneRelationStrategy::class,
+        Illuminate\Database\Eloquent\Relations\HasMany::class =>
+            Anfischer\Cloner\Strategies\PersistHasManyRelationStrategy::class,
+        Illuminate\Database\Eloquent\Relations\BelongsToMany::class =>
+            Anfischer\Cloner\Strategies\PersistBelongsToManyRelationStrategy::class,
+
+        // You can add your own strategies for relations
+        SomePackage\Relations\CustomRelation =>
+            App\Cloner\PersistenceStrategies\PersistSomePackageCustomRelationStrategy
+    ]
+];
+```
+
 
 ## Change log
 

--- a/config/cloner.php
+++ b/config/cloner.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'persistence_strategies' => [
+        Illuminate\Database\Eloquent\Relations\HasOne::class =>
+            Anfischer\Cloner\Strategies\PersistHasOneRelationStrategy::class,
+        Illuminate\Database\Eloquent\Relations\HasMany::class =>
+            Anfischer\Cloner\Strategies\PersistHasManyRelationStrategy::class,
+        Illuminate\Database\Eloquent\Relations\BelongsToMany::class =>
+            Anfischer\Cloner\Strategies\PersistBelongsToManyRelationStrategy::class,
+    ]
+];

--- a/config/cloner.php
+++ b/config/cloner.php
@@ -1,6 +1,17 @@
 <?php
 
 return [
+    /*
+    |--------------------------------------------------------------------------
+    | Persistence Strategies
+    |--------------------------------------------------------------------------
+    |
+    | These relationship types and persistence strategies are those which
+    | will be used at runtime to determine how to persist a particular
+    | type of relationship.
+    |
+    */
+
     'persistence_strategies' => [
         Illuminate\Database\Eloquent\Relations\HasOne::class =>
             Anfischer\Cloner\Strategies\PersistHasOneRelationStrategy::class,

--- a/src/ClonerServiceProvider.php
+++ b/src/ClonerServiceProvider.php
@@ -7,6 +7,18 @@ use Illuminate\Support\ServiceProvider;
 class ClonerServiceProvider extends ServiceProvider
 {
     /**
+    * Bootstrap any application services.
+    *
+    * @return void
+    */
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__.'/../config/cloner.php' => config_path('cloner.php'),
+        ], 'config');
+    }
+
+    /**
      * Register the application services.
      *
      * @return void
@@ -18,5 +30,19 @@ class ClonerServiceProvider extends ServiceProvider
         });
 
         $this->app->alias(Cloner::class, 'cloner');
+
+        $this->registerConfiguration();
+    }
+
+    /**
+    * Register the configuration required for the package.
+    *
+    * @return void
+    */
+    public function registerConfiguration()
+    {
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/cloner.php', 'cloner'
+        );
     }
 }

--- a/src/ClonerServiceProvider.php
+++ b/src/ClonerServiceProvider.php
@@ -42,7 +42,8 @@ class ClonerServiceProvider extends ServiceProvider
     public function registerConfiguration()
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../config/cloner.php', 'cloner'
+            __DIR__.'/../config/cloner.php',
+            'cloner'
         );
     }
 }

--- a/src/Exceptions/NoCompatiblePersistenceStrategyFound.php
+++ b/src/Exceptions/NoCompatiblePersistenceStrategyFound.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Anfischer\Cloner\Exceptions;
+
+use Exception;
+
+class NoCompatiblePersistenceStrategyFound extends Exception
+{
+    public static function forType(string $type): self
+    {
+        return new static("There are no compatable persistence strategies available for `{$type}`.");
+    }
+}

--- a/tests/PersistenceServiceTest.php
+++ b/tests/PersistenceServiceTest.php
@@ -7,11 +7,9 @@ use Anfischer\Cloner\Stubs\BankAccount;
 use Anfischer\Cloner\Stubs\FinancialAdviser;
 use Anfischer\Cloner\Stubs\Person;
 use Anfischer\Cloner\Stubs\CustomPerson;
-use Anfischer\Cloner\Stubs\CustomHasOne;
 use Anfischer\Cloner\Stubs\SocialSecurityNumber;
 use Anfischer\Cloner\Stubs\VerificationRule;
 use Anfischer\Cloner\Stubs\WorkAddress;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 
@@ -122,7 +120,7 @@ class PersistenceServiceTest extends TestCase
 
         $clone = (new CloneService)->clone($original);
         $clone = (new PersistenceService)->persist($clone);
-        
+
         $this->assertCount(2, Person::all());
         $this->assertEquals(
             Arr::except($original->fresh()->getAttributes(), ['id', 'created_at', 'updated_at']),

--- a/tests/Stubs/CustomHasOne.php
+++ b/tests/Stubs/CustomHasOne.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Anfischer\Cloner\Stubs;
+
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class CustomHasOne extends HasOne
+{
+}

--- a/tests/Stubs/CustomPerson.php
+++ b/tests/Stubs/CustomPerson.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Anfischer\Cloner\Stubs;
+
+use Anfischer\Cloner\Stubs\CustomHasOne;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class CustomPerson extends Model
+{
+    protected $table = 'people';
+    protected $guarded = [];
+
+    /**
+     * Instantiate a new HasOne relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  string  $foreignKey
+     * @param  string  $localKey
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    protected function newHasOne(Builder $query, Model $parent, $foreignKey, $localKey)
+    {
+        return new CustomHasOne($query, $parent, $foreignKey, $localKey);
+    }
+
+    public function socialSecurityNumber()
+    {
+        return $this->hasOne(SocialSecurityNumber::class, 'person_id');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Anfischer\Cloner\Facades\Cloner;
 use Anfischer\Cloner\Stubs\BankAccount;
 use Anfischer\Cloner\Stubs\FinancialAdviser;
 use Anfischer\Cloner\Stubs\Person;
+use Anfischer\Cloner\Stubs\CustomPerson;
 use Anfischer\Cloner\Stubs\SocialSecurityNumber;
 use Anfischer\Cloner\Stubs\VerificationRule;
 use Anfischer\Cloner\Stubs\WorkAddress;
@@ -62,6 +63,10 @@ class TestCase extends OrchestraTestCase
                 'phone' => $faker->numberBetween(60000000, 90000000),
                 'gender' => $faker->boolean,
             ];
+        });
+
+        $factory->define(CustomPerson::class, function () {
+            return factory(Person::class)->raw();
         });
 
         $factory->define(SocialSecurityNumber::class, function (Generator $faker) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change the way which Cloner detects available persistence strategies from building up a fully qualified namespace and class, to a predefined map in a configuration file.

## Motivation and context

Why is this change required? What problem does it solve?

When not using just standard relationships, or if one were to want custom behaviour in one of the existing strategies it is, technically possible currently but not intuitive and cumbersome.

For example, with the current implementation you'd have to modify the autoloader and make it look for the Anfischer\Cloner namespace in a directory within the App under a different name.

```
    "autoload": {
        "psr-4": {
            "App\\": "app/",
            "Database\\Factories\\": "database/factories/",
            "Database\\Seeders\\": "database/seeders/",
            "Anfischer\\Cloner\\Strategies\\": "app/Cloner/Strategies"
        },
    },
```

Whilst I haven't tried replacing an existing strategy by placing a file of the same name within that app/Cloner/Strategies to know if it'd work, I have extended with an additional strategy using the method above.

## How has this been tested?

Added additional tests to cover the new functionality.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Arguably breakable if you consider the fact that it is currently extendable using my example above. Users whom have added extensions to a directory and pointed the autoloader there would cease to function as expected.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
