### PR TITLE
fix: collections with one item now return as a collection when they're supposed to

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "laravel/legacy-factories": "^1.0"
   },
   "require-dev": {
-    "fzaninotto/faker": "^1.7",
+    "fakerphp/faker": "^1.18",
     "mockery/mockery": "^1.1",
     "orchestra/testbench": "^4.0|^5.0|^6.0",
     "phpunit/phpunit": "^8.4",

--- a/src/CloneService.php
+++ b/src/CloneService.php
@@ -32,26 +32,16 @@ class CloneService implements CloneServiceInterface
             Collection::wrap($item->getRelations())->each(function ($method, $relation) use ($item) {
                 $collection = $this->getFreshInstance($this->cloneRecursive($method), $item);
 
+                $isCollection = $item->getRelation($relation) instanceOf Collection;
+
                 $item->setRelation(
                     $relation,
-                    $this->getItemOrCollection($collection)
+                    $isCollection ? $collection : $collection->first()
                 );
             });
         });
 
         return $model;
-    }
-
-    /**
-     * Gets the first item of the collection if the collection
-     * only contains one item, otherwise it returns the collection
-     *
-     * @param Collection $collection
-     * @return Collection|mixed
-     */
-    private function getItemOrCollection(Collection $collection)
-    {
-        return $collection->count() > 1 ? $collection : $collection->first();
     }
 
     /**

--- a/tests/PersistenceServiceTest.php
+++ b/tests/PersistenceServiceTest.php
@@ -90,6 +90,10 @@ class PersistenceServiceTest extends TestCase
         $clone = (new PersistenceService)->persist($clone);
 
         $this->assertInstanceOf(Collection::class, $clone->bankAccounts);
+        $this->assertCount(1, $clone->bankAccounts);
+
+        // Just ensure that its not the original collection, i.e. account id 1
+        $this->assertEquals(2, $clone->bankAccounts[0]->id);
     }
 
     /** @test */


### PR DESCRIPTION
When you attach a single model to a has many relation then clone the parent model, the resulting $clone relation structure is wrong.

For example, a hasMany should always be a Collection even if there is only one related model. This not true, the model itself is attached directly to the relation i.e. `bankAcconts->bankAccount` as opposed to `bankAccounts->[bankAccount]`

## Description

Utilise the original relation structure to determine whether or not to return a collection or the first item instead of using the count of items.

## Motivation and context

Fixes a bug where the resulting structure of a relation is incorrect.

## How has this been tested?

Added an appropriate unit test.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
