### PR TITLE
fix: prevent touched models accidentally being cloned

### DIFF
--- a/src/CloneService.php
+++ b/src/CloneService.php
@@ -88,6 +88,8 @@ class CloneService implements CloneServiceInterface
 
                 $instance->setRawAttributes($attributes);
                 $instance->setRelations($original->getRelations());
+
+                $instance->setTouchedRelations([]);
             });
         });
     }

--- a/tests/Stubs/BankAccountTouchesPerson.php
+++ b/tests/Stubs/BankAccountTouchesPerson.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Anfischer\Cloner\Stubs;
+
+use Anfischer\Cloner\Stubs\Person;
+use Illuminate\Database\Eloquent\Model;
+
+class BankAccountTouchesPerson extends Model
+{
+    protected $table = 'bank_accounts';
+    protected $guarded = [];
+    protected $touches = ['person'];
+
+    public function person()
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    public function financialAdvisers()
+    {
+        return $this->belongsToMany(FinancialAdviser::class);
+    }
+}

--- a/tests/Stubs/BankAccountTouchesPerson.php
+++ b/tests/Stubs/BankAccountTouchesPerson.php
@@ -3,21 +3,14 @@
 namespace Anfischer\Cloner\Stubs;
 
 use Anfischer\Cloner\Stubs\Person;
-use Illuminate\Database\Eloquent\Model;
+use Anfischer\Cloner\Stubs\BankAccount;
 
-class BankAccountTouchesPerson extends Model
+class BankAccountTouchesPerson extends BankAccount
 {
-    protected $table = 'bank_accounts';
-    protected $guarded = [];
     protected $touches = ['person'];
 
     public function person()
     {
         return $this->belongsTo(Person::class);
-    }
-
-    public function financialAdvisers()
-    {
-        return $this->belongsToMany(FinancialAdviser::class);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Anfischer\Cloner;
 
 use Anfischer\Cloner\Facades\Cloner;
 use Anfischer\Cloner\Stubs\BankAccount;
+use Anfischer\Cloner\Stubs\BankAccountTouchesPerson;
 use Anfischer\Cloner\Stubs\FinancialAdviser;
 use Anfischer\Cloner\Stubs\Person;
 use Anfischer\Cloner\Stubs\CustomPerson;
@@ -76,6 +77,13 @@ class TestCase extends OrchestraTestCase
         });
 
         $factory->define(BankAccount::class, function (Generator $faker) {
+            return [
+                'account_number' => $faker->randomNumber(),
+                'account_name' => $faker->text(10),
+            ];
+        });
+
+        $factory->define(BankAccountTouchesPerson::class, function (Generator $faker) {
             return [
                 'account_number' => $faker->randomNumber(),
                 'account_name' => $faker->text(10),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -83,11 +83,8 @@ class TestCase extends OrchestraTestCase
             ];
         });
 
-        $factory->define(BankAccountTouchesPerson::class, function (Generator $faker) {
-            return [
-                'account_number' => $faker->randomNumber(),
-                'account_name' => $faker->text(10),
-            ];
+        $factory->define(BankAccountTouchesPerson::class, function () {
+            return factory(BankAccount::class)->raw();
         });
 
         $factory->define(WorkAddress::class, function (Generator $faker) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When models use the `protected $touches = ['relation'];` feature of eloquent, eloquent loads the relationship and as a result it gets added to the model being cloned and cloner obviously then recursively tries to clone that model too.

## Motivation and context

Why is this change required? What problem does it solve?

This PR disables model parent timestamp touches on the clone and its relations as there's no reason to update timestamps on clones as part of this process.

## How has this been tested?

I added a test which demonstrates this issue.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
